### PR TITLE
fix: remove test comment from main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 // PostureLens - App Bootstrap & Orchestrator
 // Wires together modules: capabilities, UI, canvas, capture, detection
-// Testing branch protection - this should be blocked from direct push
 
 import type { Results } from '@mediapipe/holistic'
 import { AlertEngine } from './core/alert-engine.ts'


### PR DESCRIPTION
## Summary
Removes the test comment that was added to verify branch protection rules.

## Changes
- Removed test comment from src/main.ts header

## Context
This cleanup follows the successful verification that direct pushes to main are now blocked by repository rules.